### PR TITLE
Adds support for ActionMailer without Rails

### DIFF
--- a/lib/sanitize_email.rb
+++ b/lib/sanitize_email.rb
@@ -15,7 +15,7 @@ module SanitizeEmail
   class MissingBlockParameter < StandardError; end
 
   # Allow non-rails implementations to use this gem
-  if !defined?(::Rails)
+  if !!defined?(::Rails) && defined?(::Rails::Engine) && defined?(::Rails::VERSION)
     if defined?(::Rails::Engine)
       require 'sanitize_email/engine'
     elsif ::Rails::VERSION::MAJOR == 3 && ::Rails::VERSION::MINOR.zero?
@@ -23,6 +23,8 @@ module SanitizeEmail
     else
       raise 'Please use the 0.X.X versions of sanitize_email for Rails 2.X and below.'
     end
+  elsif defined?(ActionMailer)
+    ActionMailer::Base.register_interceptor(SanitizeEmail::Bleach)
   else
     if defined?(Mailer)
       mailer = Mailer

--- a/lib/sanitize_email/config.rb
+++ b/lib/sanitize_email/config.rb
@@ -34,7 +34,7 @@ module SanitizeEmail
       # a black list
       :bad_list => nil,
 
-      :environment => if !defined?(Rails) && Rails.env.present?
+      :environment => if !!defined?(Rails) && !!defined?(Rails.env)
                         "[#{Rails.env}]"
                       else
                         '[UNKNOWN ENVIRONMENT]'


### PR DESCRIPTION
validates engine and version in top level for non rails apps

force to ignore rails

validates rails modules and variables

add support for action mailer without rails

add action_mailer directly